### PR TITLE
Throw error when failure

### DIFF
--- a/plugin/src/main/kotlin/com/slapin/gsp/task/PublishToGalaxyStore.kt
+++ b/plugin/src/main/kotlin/com/slapin/gsp/task/PublishToGalaxyStore.kt
@@ -111,7 +111,7 @@ constructor(
     withRetry(
       delay = Duration.ofSeconds(10),
       count = 5,
-      onFailure = { logger.error("Failed to register new binary") }
+      onFailure = { error("Failed to register new binary") }
     ) {
       samsungApiClient.registerBinaryFile(
         fileKey = uploadFileResponse.fileKey,


### PR DESCRIPTION
Hello,

Thanks for your work, it saved me a lot of time.

I integrated your plugin in my CI (continuous integration) job.
Issue is when task failed, Gradle is not notified and the CI's job continues as task succeed.

I replace `logger.error` by `error` to throw exception to Gradle
What do you think about this ?