### PR TITLE
feat: add submit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,6 @@ This is by design, as this plugin is intended to act as a lightweight CLI.
 
 You can override directory that will be searched for APK to upload (target variant output directory by default) by 
 specifying corresponding CLI option `./gradlew :your-app-module:publish{Variant}ToGalaxyStore --apkDirPath=/apk/dir`.
+
+You can submit app at the end of the process, by specifying corresponding CLI option 
+`./gradlew :your-app-module:publish{Variant}ToGalaxyStore --hasToSubmitApp=true`.

--- a/plugin/src/main/kotlin/com/slapin/gsp/GalaxyStorePublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/slapin/gsp/GalaxyStorePublisherPlugin.kt
@@ -1,7 +1,6 @@
 package com.slapin.gsp
 
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.gradle.internal.tasks.BundleToApkTask
 import com.slapin.gsp.task.PublishToGalaxyStore
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/plugin/src/main/kotlin/com/slapin/gsp/internal/api/SamsungApi.kt
+++ b/plugin/src/main/kotlin/com/slapin/gsp/internal/api/SamsungApi.kt
@@ -22,4 +22,9 @@ internal interface SamsungApi {
     fileKey: String,
     currentContentInfo: ContentInfo,
   ): RegisterBinaryResponse
+
+  fun submitApp(
+    currentContentInfo: ContentInfo,
+  ): Boolean
+
 }

--- a/plugin/src/main/kotlin/com/slapin/gsp/internal/api/model/ContentId.kt
+++ b/plugin/src/main/kotlin/com/slapin/gsp/internal/api/model/ContentId.kt
@@ -1,0 +1,5 @@
+package com.slapin.gsp.internal.api.model
+
+internal data class ContentId(
+    val contentId: String = "",
+)

--- a/plugin/src/main/kotlin/com/slapin/gsp/task/PublishToGalaxyStore.kt
+++ b/plugin/src/main/kotlin/com/slapin/gsp/task/PublishToGalaxyStore.kt
@@ -43,6 +43,13 @@ constructor(
   @get:Input abstract val appContentId: Property<String>
 
   @Option(
+    option = "hasToSubmitApp",
+    description = "Has to submit app for review",
+  )
+  @get:Internal
+  val hasToSubmitApp: Property<String> = objectFactory.property()
+
+  @Option(
     option = "apkDirPath",
     description = "Directory with APK to upload (variant output directory by default)",
   )
@@ -111,13 +118,20 @@ constructor(
     withRetry(
       delay = Duration.ofSeconds(10),
       count = 5,
-      onFailure = { logger.error("Failed to register new binary") }
+      onFailure = { error("Failed to register new binary") }
     ) {
       samsungApiClient.registerBinaryFile(
         fileKey = uploadFileResponse.fileKey,
         currentContentInfo = currentContentInfo,
       )
       logger.lifecycle("Successfully registered new binary")
+    }
+
+    val hasToSubmitAppValue = hasToSubmitApp.getOrElse("false")
+    logger.lifecycle("Submitting App: $hasToSubmitAppValue")
+
+    if (hasToSubmitAppValue.equals("true", ignoreCase = true)) {
+      samsungApiClient.submitApp(currentContentInfo)
     }
   }
 }


### PR DESCRIPTION
Hello,

There's a step could be added to publish flow is submit app for review.
doc [here](https://developer.samsung.com/sdp/blog/en/2022/06/02/app-management-using-the-galaxy-store-developer-api-and-python#jsblog-submit-app).
Here's a PR to add this optional step.

What do you think about this ?