### PR TITLE
Add AAB (Android App Bundle) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,28 @@ androidComponents.onVariants { variant ->
 
 ## Publishing
 
-Once setup is finished a number of tasks will be registered, e.g. if you have only `debug` and `release` variants of your 
-application, there will be two tasks `publishDebugToGalaxyStore` and `publishReleaseToGalaxyStore`.  
+Once setup is finished a number of tasks will be registered, e.g. if you have only `debug` and `release` variants of your
+application, there will be two tasks `publishDebugToGalaxyStore` and `publishReleaseToGalaxyStore`.
 
-You can list all registered tasks by running `./gradlew :your-app-module:tasks --group="Galaxy Store Publisher"`.  
+You can list all registered tasks by running `./gradlew :your-app-module:tasks --group="Galaxy Store Publisher"`.
 
-Registered tasks are not triggering corresponding apk assembling, so you'd need to assemble target apk prior to 
-publishing task invocation.  
-This is by design, as this plugin is intended to act as a lightweight CLI.
+The plugin supports both **AAB** (Android App Bundle) and **APK** formats. When both are present, AAB takes priority.
 
-You can override directory that will be searched for APK to upload (target variant output directory by default) by 
-specifying corresponding CLI option `./gradlew :your-app-module:publish{Variant}ToGalaxyStore --apkDirPath=/apk/dir`.
+Build your app before publishing:
+
+```bash
+# AAB (recommended)
+./gradlew :your-app-module:bundleRelease
+
+# APK
+./gradlew :your-app-module:assembleRelease
+```
+
+Registered tasks do not trigger the build automatically — this is by design, as this plugin is intended to act as a lightweight CLI.
+
+You can override the directories searched for binaries using CLI options:
+
+```bash
+./gradlew :your-app-module:publish{Variant}ToGalaxyStore --bundleDirPath=/aab/dir
+./gradlew :your-app-module:publish{Variant}ToGalaxyStore --apkDirPath=/apk/dir
+```

--- a/plugin/src/main/kotlin/com/slapin/gsp/GalaxyStorePublisherPlugin.kt
+++ b/plugin/src/main/kotlin/com/slapin/gsp/GalaxyStorePublisherPlugin.kt
@@ -1,7 +1,6 @@
 package com.slapin.gsp
 
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.gradle.internal.tasks.BundleToApkTask
 import com.slapin.gsp.task.PublishToGalaxyStore
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -43,8 +42,10 @@ abstract class GalaxyStorePublisherPlugin : Plugin<Project> {
           variant.buildType?.let { append("/$it") }
         }
         apkDirPath.set(layout.buildDirectory.dir(variantApkDirPath).map { it.asFile.path })
+        val variantBundleDirPath = "outputs/bundle/${variant.name}"
+        bundleDirPath.set(layout.buildDirectory.dir(variantBundleDirPath).map { it.asFile.path })
         group = "Galaxy Store Publisher"
-        description = "Publish ${variant.name} APK to Samsung Galaxy Store"
+        description = "Publish ${variant.name} binary to Samsung Galaxy Store"
       }
     }
   }

--- a/plugin/src/main/kotlin/com/slapin/gsp/task/PublishToGalaxyStore.kt
+++ b/plugin/src/main/kotlin/com/slapin/gsp/task/PublishToGalaxyStore.kt
@@ -49,6 +49,13 @@ constructor(
   @get:Internal
   val apkDirPath: Property<String> = objectFactory.property()
 
+  @Option(
+    option = "bundleDirPath",
+    description = "Directory with AAB to upload (variant output directory by default)",
+  )
+  @get:Internal
+  val bundleDirPath: Property<String> = objectFactory.property()
+
   @get:Internal
   val privateKey: Provider<String>
     get() =
@@ -57,14 +64,40 @@ constructor(
         .map(File::readText)
         .orElse(providerFactory.environmentVariable("SAMSUNG_SERVICE_ACCOUNT_KEY"))
 
+  private fun findBinary(): java.nio.file.Path {
+    if (bundleDirPath.isPresent) {
+      val bundleDir = File(bundleDirPath.get())
+      if (bundleDir.isDirectory) {
+        val aab = bundleDir.listFiles()?.firstOrNull { it.extension == "aab" }
+        if (aab != null) {
+          logger.lifecycle("Found AAB: ${aab.name}")
+          return aab.toPath()
+        }
+      }
+    }
+    if (apkDirPath.isPresent) {
+      val apkDir = File(apkDirPath.get())
+      if (apkDir.isDirectory) {
+        val apk = apkDir.listFiles()?.firstOrNull { it.extension == "apk" }
+        if (apk != null) {
+          logger.lifecycle("Found APK: ${apk.name}")
+          return apk.toPath()
+        }
+      }
+    }
+    val searched = buildList {
+      if (bundleDirPath.isPresent) add("AAB in ${bundleDirPath.get()}")
+      if (apkDirPath.isPresent) add("APK in ${apkDirPath.get()}")
+    }
+    error("No app binary (AAB or APK) found. Searched: ${searched.joinToString("; ")}")
+  }
+
   @TaskAction
   fun run() {
 
-    logger.lifecycle("Searching for APK")
+    logger.lifecycle("Searching for app binary")
 
-    val apk =
-      File(apkDirPath.get()).listFiles()?.firstOrNull { it.extension == "apk" }?.toPath()
-        ?: error("No APK found in ${apkDirPath.get()}")
+    val binary = findBinary()
 
     logger.lifecycle("Generating JWT token")
 
@@ -90,21 +123,21 @@ constructor(
 
     val uploadSession = samsungApiClient.createUploadSession()
     // Galaxy Store fails upload with the same name even though versionName/versionCode updated
-    val fixedApkName =
-      "${apk.nameWithoutExtension.replace('.', '_')}-${System.currentTimeMillis()}.${apk.extension}"
-    val fixedApk = Files.copy(apk, apk.resolveSibling(fixedApkName))
+    val fixedBinaryName =
+      "${binary.nameWithoutExtension.replace('.', '_')}-${System.currentTimeMillis()}.${binary.extension}"
+    val fixedBinary = Files.copy(binary, binary.resolveSibling(fixedBinaryName))
 
-    logger.lifecycle("Uploading $fixedApkName")
+    logger.lifecycle("Uploading $fixedBinaryName")
 
     val uploadFileResponse =
       samsungApiClient.uploadBinaryFile(
-        filePath = fixedApk.toString(),
+        filePath = fixedBinary.toString(),
         uploadSession = uploadSession,
       )
 
     logger.lifecycle("Cleaning up temporary binary")
 
-    Files.delete(fixedApk)
+    Files.delete(fixedBinary)
 
     logger.lifecycle("Registering new binary")
 


### PR DESCRIPTION
Сергей, здравия желаю!
Сделал небольшое дополнение к твоему полезному плагину.
Теперь AAB сначала ищется в выходном каталоге пакета, а если AAB не найден, используется APK. Это позволяет пользователям публиковать приложения в любом формате без изменения конфигурации плагина. Самсунгу все равно на формат файла, он принимает оба в один endpoint и с одними и теми же настройками.

EN:
AAB is now searched first in the bundle output directory, falling back to APK if no AAB is found. This lets users publish with either format without changing plugin configuration.
